### PR TITLE
feat(node,runtime): 增加构建步骤

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 dist
+
+build
+.temp

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@types/fs-extra": "^9.0.13",
     "@types/node": "^18.11.7",
     "@types/react": "^18.0.24",
     "@types/react-dom": "^18.0.8",
@@ -22,6 +23,7 @@
   "dependencies": {
     "@vitejs/plugin-react": "^2.2.0",
     "cac": "^6.7.14",
+    "fs-extra": "^11.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "vite": "^3.2.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,12 +1,14 @@
 lockfileVersion: 5.4
 
 specifiers:
+  '@types/fs-extra': ^9.0.13
   '@types/node': ^18.11.7
   '@types/react': ^18.0.24
   '@types/react-dom': ^18.0.8
   '@vitejs/plugin-react': ^2.2.0
   cac: ^6.7.14
   cz-conventional-changelog: ^3.3.0
+  fs-extra: ^11.1.0
   react: ^18.2.0
   react-dom: ^18.2.0
   typescript: ^4.8.4
@@ -15,11 +17,13 @@ specifiers:
 dependencies:
   '@vitejs/plugin-react': registry.npmmirror.com/@vitejs/plugin-react/2.2.0_vite@3.2.1
   cac: registry.npmmirror.com/cac/6.7.14
+  fs-extra: registry.npmmirror.com/fs-extra/11.1.0
   react: registry.npmmirror.com/react/18.2.0
   react-dom: registry.npmmirror.com/react-dom/18.2.0_react@18.2.0
   vite: registry.npmmirror.com/vite/3.2.1
 
 devDependencies:
+  '@types/fs-extra': registry.npmmirror.com/@types/fs-extra/9.0.13
   '@types/node': registry.npmmirror.com/@types/node/18.11.7
   '@types/react': registry.npmmirror.com/@types/react/18.0.24
   '@types/react-dom': registry.npmmirror.com/@types/react-dom/18.0.8
@@ -544,6 +548,14 @@ packages:
     version: 1.0.3
     dev: true
     optional: true
+
+  registry.npmmirror.com/@types/fs-extra/9.0.13:
+    resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/@types/fs-extra/-/fs-extra-9.0.13.tgz}
+    name: '@types/fs-extra'
+    version: 9.0.13
+    dependencies:
+      '@types/node': registry.npmmirror.com/@types/node/18.11.7
+    dev: true
 
   registry.npmmirror.com/@types/node/14.18.34:
     resolution: {integrity: sha512-hcU9AIQVHmPnmjRK+XUUYlILlr9pQrsqSrwov/JK1pnf3GTQowVBhx54FbvM0AU/VXGH4i3+vgXS5EguR7fysA==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/@types/node/-/node-14.18.34.tgz}
@@ -1382,6 +1394,17 @@ packages:
       resolve-dir: registry.npmmirror.com/resolve-dir/1.0.1
     dev: true
 
+  registry.npmmirror.com/fs-extra/11.1.0:
+    resolution: {integrity: sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/fs-extra/-/fs-extra-11.1.0.tgz}
+    name: fs-extra
+    version: 11.1.0
+    engines: {node: '>=14.14'}
+    dependencies:
+      graceful-fs: registry.npmmirror.com/graceful-fs/4.2.10
+      jsonfile: registry.npmmirror.com/jsonfile/6.1.0
+      universalify: registry.npmmirror.com/universalify/2.0.0
+    dev: false
+
   registry.npmmirror.com/fs-extra/9.1.0:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/fs-extra/-/fs-extra-9.1.0.tgz}
     name: fs-extra
@@ -1481,7 +1504,6 @@ packages:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/graceful-fs/-/graceful-fs-4.2.10.tgz}
     name: graceful-fs
     version: 4.2.10
-    dev: true
 
   registry.npmmirror.com/has-flag/3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/has-flag/-/has-flag-3.0.0.tgz}
@@ -1705,7 +1727,6 @@ packages:
       universalify: registry.npmmirror.com/universalify/2.0.0
     optionalDependencies:
       graceful-fs: registry.npmmirror.com/graceful-fs/4.2.10
-    dev: true
 
   registry.npmmirror.com/lines-and-columns/1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz}
@@ -2317,7 +2338,6 @@ packages:
     name: universalify
     version: 2.0.0
     engines: {node: '>= 10.0.0'}
-    dev: true
 
   registry.npmmirror.com/update-browserslist-db/1.0.10_browserslist@4.21.4:
     resolution: {integrity: sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz}

--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -1,0 +1,70 @@
+import { build as viteBuild, InlineConfig } from "vite";
+import { join } from "path";
+import * as fs from "fs-extra";
+
+import { CLIENT_ENTRY_PATH, SERVER_ENTRY_PATH } from "./constants";
+
+export async function bundle(root: string) {
+  const resolveViteConfig = (isServer: boolean): InlineConfig => ({
+    mode: "production",
+    root,
+    build: {
+      ssr: isServer,
+      outDir: isServer ? ".temp" : "build",
+      rollupOptions: {
+        input: isServer ? SERVER_ENTRY_PATH : CLIENT_ENTRY_PATH,
+        output: {
+          format: isServer ? "cjs" : "esm",
+        },
+      },
+    },
+  });
+
+  console.log(`Building client + server bundles...`);
+
+  try {
+    const [clientBundle, serverBundle] = await Promise.all([
+      viteBuild(resolveViteConfig(false)),
+      viteBuild(resolveViteConfig(true)),
+    ]);
+    return [clientBundle, serverBundle];
+  } catch (e) {
+    console.log(e);
+  }
+}
+
+export async function renderPage(
+  render: () => string,
+  root: string,
+  clientBundle
+) {
+  const clientChunk = clientBundle.output.find(
+    (chunk) => chunk.type === "chunk" && chunk.isEntry
+  );
+  console.log(`Rendering page in server side...`);
+  const appHtml = render();
+  const html = `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width,initial-scale=1">
+        <title>title</title>
+        <meta name="description" content="xxx">
+      </head>
+      <body>
+        <div id="root">${appHtml}</div>
+        <script type="module" src="/${clientChunk?.fileName}"></script>
+      </body>
+    </html>`.trim();
+  await fs.ensureDir(join(root, "build"));
+  await fs.writeFile(join(root, "build/index.html"), html);
+  await fs.remove(join(root, ".temp"));
+}
+
+export async function build(root: string = process.cwd()): Promise<void> {
+  const [clientBundle, serverBundle] = await bundle(root);
+  const serverEntryPath = join(root, ".temp", "ssr-entry.js");
+  const { render } = require(serverEntryPath);
+  await renderPage(render, root, clientBundle);
+}

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -1,5 +1,7 @@
 import cac from "cac";
+import { resolve } from "path";
 import { createDevServer } from "./dev";
+import { build } from "./build";
 
 const cli = cac("island").version("0.0.1").help();
 
@@ -12,7 +14,12 @@ cli.command("dev [root]", "start dev server").action(async (root: string) => {
 cli
   .command("build [root]", "build in production")
   .action(async (root: string) => {
-    console.log("build paramters:", root);
+    try {
+      root = resolve(root);
+      await build(root);
+    } catch (e) {
+      console.log(e);
+    }
   });
 
 cli.parse();

--- a/src/node/constants/index.ts
+++ b/src/node/constants/index.ts
@@ -5,4 +5,10 @@ export const CLIENT_ENTRY_PATH = join(
   PACKAGE_ROOT,
   "src/runtime/client-entry.tsx"
 );
+
+export const SERVER_ENTRY_PATH = join(
+  PACKAGE_ROOT,
+  "src/runtime/ssr-entry.tsx"
+);
+
 export const DEFAULT_TEMPLATE_PATH = join(PACKAGE_ROOT, "template.html");

--- a/src/runtime/client-entry.tsx
+++ b/src/runtime/client-entry.tsx
@@ -1,12 +1,9 @@
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
 
-function renderInBrowser() {
+function render() {
   const containerEl = document.getElementById("root");
-  if (!containerEl) {
-    throw new Error("#root element not found");
-  }
   createRoot(containerEl).render(<App />);
 }
 
-renderInBrowser();
+render();

--- a/src/runtime/ssr-entry.tsx
+++ b/src/runtime/ssr-entry.tsx
@@ -1,0 +1,6 @@
+import { App } from "./app";
+import { renderToString } from "react-dom/server";
+
+export function render() {
+  return renderToString(<App />);
+}


### PR DESCRIPTION
分别构建client和服务端产物。在构建ssg产物时，将组建代码生成字符串，然后和html文件拼接。最终产物只有client.js和被注入过的html文件